### PR TITLE
Fix shader binarization failure after wgpu/naga update

### DIFF
--- a/crates/plugins/binarizer/src/compilers/shader_compiler.rs
+++ b/crates/plugins/binarizer/src/compilers/shader_compiler.rs
@@ -305,7 +305,18 @@ impl<const PLATFORM_TYPE: PlatformType> ShaderCompiler<PLATFORM_TYPE> {
             let mut data = Vec::new();
             file.read_to_end(&mut data).unwrap();
             let shader_code = String::from_utf8(data).unwrap();
-            let preprocessed_code = Self::preprocess_code(path, shader_code);
+            let mut preprocessed_code = Self::preprocess_code(path, shader_code);
+            preprocessed_code = Self::remove_comments(&preprocessed_code);
+
+            let result = clean_unused_definitions(&preprocessed_code);
+            match result {
+                Ok(code) => {
+                    preprocessed_code = code;
+                }
+                Err(e) => {
+                    println!("Unable to optimize shader {path:?} with error: \n{}", e,);
+                }
+            }
 
             if self.validate_shader(&preprocessed_code, path, &new_path) {
                 let shader_data = ShaderData {

--- a/crates/plugins/binarizer/src/compilers/shader_compiler.rs
+++ b/crates/plugins/binarizer/src/compilers/shader_compiler.rs
@@ -169,6 +169,10 @@ impl<const PLATFORM_TYPE: PlatformType> ShaderCompiler<PLATFORM_TYPE> {
                         spirv_code,
                         ..Default::default()
                     };
+                    if !new_path.exists() {
+                        let result = create_dir_all(new_path.parent().unwrap());
+                        debug_assert!(result.is_ok());
+                    }
                     shader_data.save_to_file(new_path.as_path(), SerializationType::Binary);
                     send_reloaded_event(&self.message_hub, new_path.as_path());
                 }
@@ -323,6 +327,10 @@ impl<const PLATFORM_TYPE: PlatformType> ShaderCompiler<PLATFORM_TYPE> {
                     wgsl_code: preprocessed_code,
                     ..Default::default()
                 };
+                if !new_path.exists() {
+                    let result = create_dir_all(new_path.parent().unwrap());
+                    debug_assert!(result.is_ok());
+                }
                 shader_data.save_to_file(new_path.as_path(), SerializationType::Binary);
                 send_reloaded_event(&self.message_hub, new_path.as_path());
             }


### PR DESCRIPTION
The user reported that shaders were not being binarized/serialized correctly after updating dependencies (wgpu/naga). 

Investigation revealed that `create_wgsl_shader_data` (used by the binarizer watcher) was skipping the `clean_unused_definitions` step, which is performed in the manual `preprocess_shader` task. This step uses `naga` to parse, compact (remove dead code), and validate the shader.

This change updates `create_wgsl_shader_data` to:
1. Call `remove_comments` (for consistency).
2. Call `clean_unused_definitions` to optimize and validate the shader.
3. Handle errors from the optimization step gracefully (logging them instead of crashing).
4. Proceed to final validation and saving only if the shader is valid.

This ensures that the binarizer produces valid, optimized WGSL code compatible with the updated `wgpu`/`naga` validation rules.

---
*PR created automatically by Jules for task [294426685409377458](https://jules.google.com/task/294426685409377458) started by @gents83*