### PR TITLE
Fix Rust Web workflow dependencies

### DIFF
--- a/.github/workflows/rust-web.yml
+++ b/.github/workflows/rust-web.yml
@@ -67,7 +67,7 @@ jobs:
         run: cargo build --manifest-path ./crates/Cargo.toml --release --target wasm32-unknown-unknown
 
       - name: "Install wasm bindgen"
-        run: cargo install -f wasm-bindgen-cli
+        run: cargo install -f wasm-bindgen-cli --version 0.2.108
 
       - name: "Run wasm bindgen"
         run: wasm-bindgen ./crates/target/wasm32-unknown-unknown/release/inox_launcher.wasm --out-dir ./output/web/ --target web --no-typescript --no-demangle --keep-lld-exports --split-linked-modules

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -133,10 +133,10 @@ erased-serde = { version = "0.4.5" }
 rspirv = { version = "0.11" }
 
 # wasm32
-js-sys = { version = "0.3.77" }
-wasm-bindgen = { version = "0.2.108" }
-wasm-bindgen-futures = { version = "0.4.43" }
-web-sys = { version = "0.3.77", features = [
+js-sys = { version = "=0.3.85" }
+wasm-bindgen = { version = "=0.2.108" }
+wasm-bindgen-futures = { version = "=0.4.58" }
+web-sys = { version = "=0.3.85", features = [
     "Request",
     "Response",
     "Document",


### PR DESCRIPTION
Fixes the Rust Web workflow failure caused by `wasm-bindgen` version mismatch and `web-sys` 0.3.87 API changes breaking `glow` compilation. Pinned all wasm-related dependencies to a known working set (wasm-bindgen 0.2.108, web-sys 0.3.85).

---
*PR created automatically by Jules for task [8338576627230663672](https://jules.google.com/task/8338576627230663672) started by @gents83*